### PR TITLE
Gradle code validation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,7 +31,7 @@ jobs:
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/setup-gradle@V5 # I think v5, changed from base per their github.
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build --build-cache


### PR DESCRIPTION
Something I've noticed from time to time is that people may forget to ensure code builds and do so before submission. This should assist with that if I understand it correctly, following a basic setup per: https://github.com/wpilibsuite/allwpilib?tab=readme-ov-file 
Which should help ensure code works in main automatically.
There is likely at least some small issues within this and we may want to heavily modify this.
That say, I believe it a good idea, at least for ensuring code builds before it can be merged to main.