### PR TITLE
Setup Gradle code validation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
     # This grabs the WPILib docker container
-    container: wpilib/roborio-cross-ubuntu:2026-22.04-py314
+    container: wpilib/roborio-cross-ubuntu:2025-22.04
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v4


### PR DESCRIPTION
Something I've noticed from time to time is that people may forget to ensure code builds and do so before committing. This will assist with that, ensuring code builds before it can be merged to main.