### PR TITLE
Add manual shooter mode and turret safety updates

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -155,7 +155,7 @@ public final class Constants
         public static final Current                                   FLYWHEEL_CURRENT_LIMIT = Amps.of(60);
         public static final AngularVelocity                           MANUAL_SHOOT_RPM       = RPM.of(3500.0);
         public static final AngularVelocity                           PASS_FLYWHEEL_VELOCITY = RPM.of(3000.0); // TODO: Tune
-        private static final AngularVelocity                          SMART_SHOOT_RPM_BIAS   = RPM.of(100.0);
+        private static final AngularVelocity                          SMART_SHOOT_RPM_BIAS   = RPM.of(150.0);
 
         // Turret
         public static final Current       TURRET_CURRENT_LIMIT                  = Amps.of(40.0);
@@ -192,11 +192,11 @@ public final class Constants
         // @formatter:off
         private static final InterpolatingDoubleTreeMap FLYWHEEL_SPEED_TABLE = InterpolatingDoubleTreeMap.ofEntries
         (
-            Map.entry(68.0, 3000.0),
-            Map.entry(77.0, 3050.0),
-            Map.entry(108.0, 3700.0),
-            Map.entry(113.0, 3850.0),
-            Map.entry(138.0, 4350.0)
+            Map.entry(68.0, 3100.0),
+            Map.entry(77.0, 3150.0),
+            Map.entry(108.0, 3800.0),
+            Map.entry(113.0, 3950.0),
+            Map.entry(138.0, 4450.0)
         );
         // @formatter:on
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,6 +7,7 @@ import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
 import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Milliseconds;
 import static edu.wpi.first.units.Units.Percent;
 import static edu.wpi.first.units.Units.Rotations;
@@ -36,6 +37,7 @@ import edu.wpi.first.units.AngularVelocityUnit;
 import edu.wpi.first.units.DistanceUnit;
 import edu.wpi.first.units.VoltageUnit;
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Dimensionless;
@@ -93,12 +95,23 @@ public final class Constants
 
     public static class DriveConstants
     {
-        public static final LinearVelocity  MAX_SPEED          = TunerConstants.kSpeedAt12Volts.times(0.5); // kSpeedAt12Volts desired top speed
-        public static final AngularVelocity MAX_ANGULAR_RATE   = RotationsPerSecond.of(0.75); // 3/4 of a rotation per second max angular velocity
-        public static final Dimensionless   TRANSLATE_DEADBAND = Percent.of(8);
-        public static final Dimensionless   ROTATE_DEADBAND    = Percent.of(8);
-        public static final Dimensionless   SLOW_MODE_SCALE    = Percent.of(35);
-        public static final Dimensionless   FULL_SPEED_SCALE   = Percent.of(100);
+        public static final LinearVelocity MAX_SPEED = TunerConstants.kSpeedAt12Volts.times(0.5); // kSpeedAt12Volts
+        // desired top speed
+        public static final AngularVelocity     MAX_ANGULAR_RATE                      = RotationsPerSecond.of(0.75); // 3/4 of a rotation per
+                                                                                                                     // second max angular
+                                                                                                                     // velocity
+        public static final Dimensionless       TRANSLATE_DEADBAND                    = Percent.of(8);
+        public static final Dimensionless       ROTATE_DEADBAND                       = Percent.of(8);
+        public static final Dimensionless       SLOW_MODE_SCALE                       = Percent.of(35);
+        public static final Dimensionless       FULL_SPEED_SCALE                      = Percent.of(100);
+        public static final double              SNAKE_HEADING_KP                      = 4.5;
+        public static final double              SNAKE_HEADING_KD                      = 0.2;
+        public static final LinearVelocity      SNAKE_MIN_TRANSLATE_FOR_HEADING       = MetersPerSecond.of(0.2);
+        public static final double              SNAKE_ROTATION_OVERRIDE_AXIS_DEADBAND = 0.12;
+        public static final AngularVelocity     SNAKE_MAX_ANGULAR_RATE                = MAX_ANGULAR_RATE;
+        public static final AngularAcceleration SNAKE_MAX_ANGULAR_ACCELERATION        = RotationsPerSecondPerSecond.of(1.5);
+        public static final Angle               SNAKE_INTAKE_HEADING_OFFSET           = Degrees.of(180.0); // Intake faces the rear
+        public static final Angle               SNAKE_HEADING_TOLERANCE               = Degrees.of(2.0);
     }
 
     public static class IntakeConstants
@@ -133,11 +146,11 @@ public final class Constants
     {
         // Flywheel
         public static final double                                    FLYWHEEL_KP            = 0.00015; // TODO: Tune
-        public static final double                                    FLYWHEEL_KI            = 0.0;    // TODO: Tune
+        public static final double                                    FLYWHEEL_KI            = 0.0; // TODO: Tune
         public static final double                                    FLYWHEEL_KD            = 0.0005;
-        public static final Voltage                                   FLYWHEEL_KS            = Volts.of(0.0);            // TODO: Tune - static friction voltage
+        public static final Voltage                                   FLYWHEEL_KS            = Volts.of(0.0); // TODO: Tune - static friction voltage
         public static final Per<VoltageUnit, AngularVelocityUnit>     FLYWHEEL_KV            = Volts.of(12.0).div(RPM.of(6784.0));
-        public static final Per<VoltageUnit, AngularAccelerationUnit> FLYWHEEL_KA            = Volts.of(0).per(RotationsPerSecondPerSecond);            // TODO: Tune - acceleration voltage
+        public static final Per<VoltageUnit, AngularAccelerationUnit> FLYWHEEL_KA            = Volts.of(0).per(RotationsPerSecondPerSecond); // TODO: Tune - acceleration voltage
         public static final Dimensionless                             FLYWHEEL_TOLERANCE     = Percent.of(15);
         public static final Current                                   FLYWHEEL_CURRENT_LIMIT = Amps.of(60);
         public static final AngularVelocity                           MANUAL_SHOOT_RPM       = RPM.of(3500.0);
@@ -146,7 +159,7 @@ public final class Constants
 
         // Turret
         public static final Current       TURRET_CURRENT_LIMIT                  = Amps.of(40.0);
-        public static final double        TURRET_KP                             = 0.12;    // TODO: Tune (onboard TalonFX PID)
+        public static final double        TURRET_KP                             = 0.04; // TODO: Tune (onboard TalonFX PID)
         public static final double        TURRET_KI                             = 0.0;
         public static final double        TURRET_KD                             = 0.0115;
         public static final Dimensionless TURRET_GEAR_RATIO                     = Value.of(13.0 / 1.0); // 13 : 1
@@ -155,8 +168,9 @@ public final class Constants
         public static final Angle         TURRET_SOFT_MIN_ANGLE                 = Degrees.of(-160.0); // degrees (full 360 rotation)
         public static final Angle         TURRET_SOFT_MAX_ANGLE                 = Degrees.of(160.0);  // degrees
         public static final boolean       TURRET_SENSOR_INVERTED                = true;
-        public static final Angle         TURRET_HOME_ANGLE                     = Degrees.of(90.0);   // Forward-facing when no target
-        public static final Angle         TURRET_TOLERANCE                      = Degrees.of(2.0);   // degrees
+        public static final Angle         TURRET_HOME_ANGLE                     = Degrees.of(0.0); // Forward-facing when no target
+        public static final Angle         TURRET_TOLERANCE                      = Degrees.of(2.0); // degrees
+        public static final Angle         TURRET_TRACK_TX_DEADBAND              = Degrees.of(0.75);
         public static final String        LIMELIGHT_NAME                        = "limelight-shooter";
         public static final Angle         TURRET_PASS_TARGET                    = Degrees.of(180.0); // TODO: Validate in driver practice
         public static final Distance      TURRET_CENTER_TAG_TO_HUB_CENTER       = Inches.of(23.5);
@@ -164,7 +178,8 @@ public final class Constants
         public static final List<Integer> RED_HUB_TAG_IDS                       = List.of(2, 4, 5, 10);
         public static final List<Integer> ALL_HUB_TAG_IDS                       = Stream.concat(BLUE_HUB_TAG_IDS.stream(), RED_HUB_TAG_IDS.stream()).toList();
         public static final Translation3d CENTER_TAG_TO_HUB_CENTER_OFFSET       = new Translation3d(Inches.of(-23.5), Inches.zero(), Inches.zero());
-        public static final Angle         TURRET_ZERO_OFFSET_FROM_ROBOT_FORWARD = Degrees.of(90); // Hub "zero" is 90 degrees left of robot forward
+        public static final Angle         TURRET_ZERO_OFFSET_FROM_ROBOT_FORWARD = Degrees.of(90); // Hub "zero" is 90 degrees
+                                                                                                  // left of robot forward
         public static final Translation2d BLUE_HUB                              = new Translation2d(Inches.of(182.1), Inches.of(158.85));
         public static final Translation2d RED_HUB                               = new Translation2d(Inches.of(469.1), Inches.of(158.85));
         public static final Translation2d TURRET_POSITION                       = new Translation2d(Inches.of(-0.5), Inches.of(5.75));
@@ -177,11 +192,11 @@ public final class Constants
         // @formatter:off
         private static final InterpolatingDoubleTreeMap FLYWHEEL_SPEED_TABLE = InterpolatingDoubleTreeMap.ofEntries
         (
-            Map.entry(52.0, 2840.0),
-            Map.entry(69.0, 3000.0),
-            Map.entry(94.0, 3450.0),
-            Map.entry(114.0, 4175.0),
-            Map.entry(156.0, 5290.0)
+            Map.entry(68.0, 3000.0),
+            Map.entry(77.0, 3050.0),
+            Map.entry(108.0, 3700.0),
+            Map.entry(113.0, 3850.0),
+            Map.entry(138.0, 4350.0)
         );
         // @formatter:on
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -170,7 +170,7 @@ public final class Constants
         public static final boolean       TURRET_SENSOR_INVERTED                = true;
         public static final Angle         TURRET_HOME_ANGLE                     = Degrees.of(0.0); // Forward-facing when no target
         public static final Angle         TURRET_TOLERANCE                      = Degrees.of(2.0); // degrees
-        public static final Angle         TURRET_TRACK_TX_DEADBAND              = Degrees.of(0.75);
+        public static final Angle         TURRET_TRACK_TX_DEADBAND              = Degrees.of(2);
         public static final String        LIMELIGHT_NAME                        = "limelight-shooter";
         public static final Angle         TURRET_PASS_TARGET                    = Degrees.of(180.0); // TODO: Validate in driver practice
         public static final Distance      TURRET_CENTER_TAG_TO_HUB_CENTER       = Inches.of(23.5);
@@ -192,11 +192,14 @@ public final class Constants
         // @formatter:off
         private static final InterpolatingDoubleTreeMap FLYWHEEL_SPEED_TABLE = InterpolatingDoubleTreeMap.ofEntries
         (
-            Map.entry(68.0, 3100.0),
-            Map.entry(77.0, 3150.0),
-            Map.entry(108.0, 3800.0),
-            Map.entry(113.0, 3950.0),
-            Map.entry(138.0, 4450.0)
+            Map.entry(50.0, 2500.0),
+            Map.entry(75.5, 2950.0),
+            Map.entry(101.0, 3400.0),
+            Map.entry(113.0, 3850.0),
+            Map.entry(130.0, 4050.0),
+            Map.entry(151.0, 4600.0),
+            Map.entry(183.0, 5100.0),
+            Map.entry(204.0, 5850.0)
         );
         // @formatter:on
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -97,21 +97,13 @@ public final class Constants
     {
         public static final LinearVelocity MAX_SPEED = TunerConstants.kSpeedAt12Volts.times(0.5); // kSpeedAt12Volts
         // desired top speed
-        public static final AngularVelocity     MAX_ANGULAR_RATE                      = RotationsPerSecond.of(0.75); // 3/4 of a rotation per
-                                                                                                                     // second max angular
-                                                                                                                     // velocity
-        public static final Dimensionless       TRANSLATE_DEADBAND                    = Percent.of(8);
-        public static final Dimensionless       ROTATE_DEADBAND                       = Percent.of(8);
-        public static final Dimensionless       SLOW_MODE_SCALE                       = Percent.of(35);
-        public static final Dimensionless       FULL_SPEED_SCALE                      = Percent.of(100);
-        public static final double              SNAKE_HEADING_KP                      = 4.5;
-        public static final double              SNAKE_HEADING_KD                      = 0.2;
-        public static final LinearVelocity      SNAKE_MIN_TRANSLATE_FOR_HEADING       = MetersPerSecond.of(0.2);
-        public static final double              SNAKE_ROTATION_OVERRIDE_AXIS_DEADBAND = 0.12;
-        public static final AngularVelocity     SNAKE_MAX_ANGULAR_RATE                = MAX_ANGULAR_RATE;
-        public static final AngularAcceleration SNAKE_MAX_ANGULAR_ACCELERATION        = RotationsPerSecondPerSecond.of(1.5);
-        public static final Angle               SNAKE_INTAKE_HEADING_OFFSET           = Degrees.of(180.0); // Intake faces the rear
-        public static final Angle               SNAKE_HEADING_TOLERANCE               = Degrees.of(2.0);
+        public static final AngularVelocity MAX_ANGULAR_RATE   = RotationsPerSecond.of(0.75); // 3/4 of a rotation per
+                                                                                              // second max angular
+                                                                                              // velocity
+        public static final Dimensionless   TRANSLATE_DEADBAND = Percent.of(8);
+        public static final Dimensionless   ROTATE_DEADBAND    = Percent.of(8);
+        public static final Dimensionless   SLOW_MODE_SCALE    = Percent.of(35);
+        public static final Dimensionless   FULL_SPEED_SCALE   = Percent.of(100);
     }
 
     public static class IntakeConstants
@@ -178,7 +170,7 @@ public final class Constants
         public static final List<Integer> RED_HUB_TAG_IDS                       = List.of(2, 4, 5, 10);
         public static final List<Integer> ALL_HUB_TAG_IDS                       = Stream.concat(BLUE_HUB_TAG_IDS.stream(), RED_HUB_TAG_IDS.stream()).toList();
         public static final Translation3d CENTER_TAG_TO_HUB_CENTER_OFFSET       = new Translation3d(Inches.of(-23.5), Inches.zero(), Inches.zero());
-        public static final Angle         TURRET_ZERO_OFFSET_FROM_ROBOT_FORWARD = Degrees.of(90); // Hub "zero" is 90 degrees
+        public static final Angle         TURRET_ZERO_OFFSET_FROM_ROBOT_FORWARD = Degrees.of(90); // Turret "zero" is 90 degrees
                                                                                                   // left of robot forward
         public static final Translation2d BLUE_HUB                              = new Translation2d(Inches.of(182.1), Inches.of(158.85));
         public static final Translation2d RED_HUB                               = new Translation2d(Inches.of(469.1), Inches.of(158.85));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -54,13 +54,8 @@ public class RobotContainer
     private final Autos                      _autos             = new Autos(_drive, _shooter);
     @NotLogged
     private final ProfiledPIDController      _snakeController   = new ProfiledPIDController(
-            DriveConstants.SNAKE_HEADING_KP,
-            0.0,
-            DriveConstants.SNAKE_HEADING_KD,
-            new TrapezoidProfile.Constraints(
-                    DriveConstants.SNAKE_MAX_ANGULAR_RATE.in(RadiansPerSecond),
-                    DriveConstants.SNAKE_MAX_ANGULAR_ACCELERATION.in(RadiansPerSecondPerSecond)
-            )
+            DriveConstants.SNAKE_HEADING_KP, 0.0, DriveConstants.SNAKE_HEADING_KD,
+            new TrapezoidProfile.Constraints(DriveConstants.SNAKE_MAX_ANGULAR_RATE.in(RadiansPerSecond), DriveConstants.SNAKE_MAX_ANGULAR_ACCELERATION.in(RadiansPerSecondPerSecond))
     );
     private Dimensionless                    _driveMultiplier   = DriveConstants.FULL_SPEED_SCALE;
     private double                           _manualFlywheelRPM = MANUAL_FLYWHEEL_START_RPM;
@@ -128,8 +123,7 @@ public class RobotContainer
 
         if (translationMagnitude > DriveConstants.SNAKE_MIN_TRANSLATE_FOR_HEADING.in(MetersPerSecond))
         {
-            var desiredHeadingRadians = Math.atan2(strafe.in(MetersPerSecond), drive.in(MetersPerSecond))
-                    + DriveConstants.SNAKE_INTAKE_HEADING_OFFSET.in(Radians);
+            var desiredHeadingRadians = Math.atan2(strafe.in(MetersPerSecond), drive.in(MetersPerSecond)) + DriveConstants.SNAKE_INTAKE_HEADING_OFFSET.in(Radians);
             _snakeHeading = Rotation2d.fromRadians(MathUtil.angleModulus(desiredHeadingRadians));
         }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,9 +4,6 @@
 package frc.robot;
 
 import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.Radians;
-import static edu.wpi.first.units.Units.RadiansPerSecond;
-import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Value;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
@@ -14,10 +11,6 @@ import com.ctre.phoenix6.swerve.SwerveRequest;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
-import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.math.controller.ProfiledPIDController;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Dimensionless;
 import edu.wpi.first.units.measure.LinearVelocity;
@@ -26,7 +19,6 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.subsystems.drive.Drive;
 import frc.robot.subsystems.drive.TunerConstants;
@@ -46,26 +38,16 @@ public class RobotContainer
     private final Telemetry                  _logger            = new Telemetry(DriveConstants.MAX_SPEED.in(MetersPerSecond));
     private final CommandJoystick            _driver            = new CommandJoystick(0);
     private final CommandXboxController      _operator          = new CommandXboxController(1);
-    private final Trigger                    _snakeMode         = _driver.button(4);
     private final Drive                      _drive             = TunerConstants.createDrivetrain();
     private final Intake                     _intake            = new Intake();
     private final Shooter                    _shooter           = new Shooter(_drive::getState);
     @NotLogged
     private final Autos                      _autos             = new Autos(_drive, _shooter);
-    @NotLogged
-    private final ProfiledPIDController      _snakeController   = new ProfiledPIDController(
-            DriveConstants.SNAKE_HEADING_KP, 0.0, DriveConstants.SNAKE_HEADING_KD,
-            new TrapezoidProfile.Constraints(DriveConstants.SNAKE_MAX_ANGULAR_RATE.in(RadiansPerSecond), DriveConstants.SNAKE_MAX_ANGULAR_ACCELERATION.in(RadiansPerSecondPerSecond))
-    );
     private Dimensionless                    _driveMultiplier   = DriveConstants.FULL_SPEED_SCALE;
     private double                           _manualFlywheelRPM = MANUAL_FLYWHEEL_START_RPM;
-    private Rotation2d                       _snakeHeading      = Rotation2d.kZero;
-    private boolean                          _wasSnakeModeOn    = false;
 
     public RobotContainer()
     {
-        _snakeController.enableContinuousInput(-Math.PI, Math.PI);
-        _snakeController.setTolerance(DriveConstants.SNAKE_HEADING_TOLERANCE.in(Radians));
         configureBindings();
     }
 
@@ -86,54 +68,7 @@ public class RobotContainer
 
     private SwerveRequest.FieldCentric getFieldCentricRequest()
     {
-        var drive   = getDrive();
-        var strafe  = getStrafe();
-        var rotate  = getRotate();
-        var heading = _drive.getState().Pose.getRotation();
-        var snakeOn = _snakeMode.getAsBoolean();
-
-        if (snakeOn && !_wasSnakeModeOn)
-        {
-            resetSnakeMode(heading);
-        }
-        else if (!snakeOn && _wasSnakeModeOn)
-        {
-            _wasSnakeModeOn = false;
-        }
-
-        _wasSnakeModeOn = snakeOn;
-
-        if (!snakeOn)
-        {
-            return _fieldCentric.withVelocityX(drive).withVelocityY(strafe).withRotationalRate(rotate);
-        }
-
-        return _fieldCentric.withVelocityX(drive).withVelocityY(strafe).withRotationalRate(getSnakeRotate(drive, strafe, rotate, heading));
-    }
-
-    private AngularVelocity getSnakeRotate(LinearVelocity drive, LinearVelocity strafe, AngularVelocity manualRotate, Rotation2d robotHeading)
-    {
-        if (Math.abs(_driver.getTwist()) > DriveConstants.SNAKE_ROTATION_OVERRIDE_AXIS_DEADBAND)
-        {
-            resetSnakeMode(robotHeading);
-            return manualRotate;
-        }
-
-        var translationMagnitude = Math.hypot(drive.in(MetersPerSecond), strafe.in(MetersPerSecond));
-
-        if (translationMagnitude > DriveConstants.SNAKE_MIN_TRANSLATE_FOR_HEADING.in(MetersPerSecond))
-        {
-            var desiredHeadingRadians = Math.atan2(strafe.in(MetersPerSecond), drive.in(MetersPerSecond)) + DriveConstants.SNAKE_INTAKE_HEADING_OFFSET.in(Radians);
-            _snakeHeading = Rotation2d.fromRadians(MathUtil.angleModulus(desiredHeadingRadians));
-        }
-
-        return RadiansPerSecond.of(_snakeController.calculate(robotHeading.getRadians(), _snakeHeading.getRadians()));
-    }
-
-    private void resetSnakeMode(Rotation2d robotHeading)
-    {
-        _snakeHeading = robotHeading;
-        _snakeController.reset(robotHeading.getRadians(), _drive.getState().Speeds.omegaRadiansPerSecond);
+        return _fieldCentric.withVelocityX(getDrive()).withVelocityY(getStrafe()).withRotationalRate(getRotate());
     }
 
     private void setManualFlywheelRPM(double rpm)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -166,6 +166,7 @@ public class RobotContainer
         _operator.x().onTrue(Commands.runOnce(() -> setManualFlywheelRPM(_manualFlywheelRPM - MANUAL_FLYWHEEL_STEP_RPM)).onlyIf(_shooter::inManualMode));
         _operator.b().onTrue(Commands.runOnce(() -> setManualFlywheelRPM(_manualFlywheelRPM + MANUAL_FLYWHEEL_STEP_RPM)).onlyIf(_shooter::inManualMode));
         _operator.a().onTrue(Commands.runOnce(_shooter::stopManualFlywheel).onlyIf(_shooter::inManualMode));
+        _operator.rightBumper().whileTrue(_shooter.runManualFeeder());
         _operator.povDown().onTrue(_intake.getRetractCmd());
         _operator.povUp().onTrue(_intake.getExtendCmd());
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,15 +4,20 @@
 package frc.robot;
 
 import static edu.wpi.first.units.Units.MetersPerSecond;
-import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.Radians;
+import static edu.wpi.first.units.Units.RadiansPerSecond;
+import static edu.wpi.first.units.Units.RadiansPerSecondPerSecond;
 import static edu.wpi.first.units.Units.Value;
 
 import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
-
 import com.ctre.phoenix6.swerve.SwerveRequest;
 
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Dimensionless;
 import edu.wpi.first.units.measure.LinearVelocity;
@@ -21,8 +26,8 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.Constants.DriveConstants;
-import frc.robot.Constants.ShooterConstants;
 import frc.robot.subsystems.drive.Drive;
 import frc.robot.subsystems.drive.TunerConstants;
 import frc.robot.subsystems.intake.Intake;
@@ -32,21 +37,40 @@ import frc.robot.util.MeasureUtil;
 @Logged
 public class RobotContainer
 {
+    private static final double MANUAL_FLYWHEEL_START_RPM = 3500.0;
+    private static final double MANUAL_FLYWHEEL_STEP_RPM  = 50.0;
+
     /* Setting up bindings for necessary control of the swerve drive platform */
-    private final SwerveRequest.FieldCentric _fieldCentric    = new SwerveRequest.FieldCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage); // Use open-loop control for drive motors
-    private final SwerveRequest.RobotCentric _robotCentric    = new SwerveRequest.RobotCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage);
-    private final Telemetry                  _logger          = new Telemetry(DriveConstants.MAX_SPEED.in(MetersPerSecond));
-    private final CommandJoystick            _driver          = new CommandJoystick(0);
-    private final CommandXboxController      _operator        = new CommandXboxController(1);
-    private final Drive                      _drive           = TunerConstants.createDrivetrain();
-    private final Intake                     _intake          = new Intake();
-    private final Shooter                    _shooter         = new Shooter(_drive::getState);
+    private final SwerveRequest.FieldCentric _fieldCentric      = new SwerveRequest.FieldCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+    private final SwerveRequest.RobotCentric _robotCentric      = new SwerveRequest.RobotCentric().withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+    private final Telemetry                  _logger            = new Telemetry(DriveConstants.MAX_SPEED.in(MetersPerSecond));
+    private final CommandJoystick            _driver            = new CommandJoystick(0);
+    private final CommandXboxController      _operator          = new CommandXboxController(1);
+    private final Trigger                    _snakeMode         = _driver.button(4);
+    private final Drive                      _drive             = TunerConstants.createDrivetrain();
+    private final Intake                     _intake            = new Intake();
+    private final Shooter                    _shooter           = new Shooter(_drive::getState);
     @NotLogged
-    private final Autos                      _autos           = new Autos(_drive, _shooter);
-    private Dimensionless                    _driveMultiplier = DriveConstants.FULL_SPEED_SCALE;
+    private final Autos                      _autos             = new Autos(_drive, _shooter);
+    @NotLogged
+    private final ProfiledPIDController      _snakeController   = new ProfiledPIDController(
+            DriveConstants.SNAKE_HEADING_KP,
+            0.0,
+            DriveConstants.SNAKE_HEADING_KD,
+            new TrapezoidProfile.Constraints(
+                    DriveConstants.SNAKE_MAX_ANGULAR_RATE.in(RadiansPerSecond),
+                    DriveConstants.SNAKE_MAX_ANGULAR_ACCELERATION.in(RadiansPerSecondPerSecond)
+            )
+    );
+    private Dimensionless                    _driveMultiplier   = DriveConstants.FULL_SPEED_SCALE;
+    private double                           _manualFlywheelRPM = MANUAL_FLYWHEEL_START_RPM;
+    private Rotation2d                       _snakeHeading      = Rotation2d.kZero;
+    private boolean                          _wasSnakeModeOn    = false;
 
     public RobotContainer()
     {
+        _snakeController.enableContinuousInput(-Math.PI, Math.PI);
+        _snakeController.setTolerance(DriveConstants.SNAKE_HEADING_TOLERANCE.in(Radians));
         configureBindings();
     }
 
@@ -65,19 +89,73 @@ public class RobotContainer
         return MeasureUtil.applyDeadband(DriveConstants.MAX_ANGULAR_RATE.times(Value.of(-_driver.getTwist())).times(_driveMultiplier), DriveConstants.ROTATE_DEADBAND);
     }
 
+    private SwerveRequest.FieldCentric getFieldCentricRequest()
+    {
+        var drive   = getDrive();
+        var strafe  = getStrafe();
+        var rotate  = getRotate();
+        var heading = _drive.getState().Pose.getRotation();
+        var snakeOn = _snakeMode.getAsBoolean();
+
+        if (snakeOn && !_wasSnakeModeOn)
+        {
+            resetSnakeMode(heading);
+        }
+        else if (!snakeOn && _wasSnakeModeOn)
+        {
+            _wasSnakeModeOn = false;
+        }
+
+        _wasSnakeModeOn = snakeOn;
+
+        if (!snakeOn)
+        {
+            return _fieldCentric.withVelocityX(drive).withVelocityY(strafe).withRotationalRate(rotate);
+        }
+
+        return _fieldCentric.withVelocityX(drive).withVelocityY(strafe).withRotationalRate(getSnakeRotate(drive, strafe, rotate, heading));
+    }
+
+    private AngularVelocity getSnakeRotate(LinearVelocity drive, LinearVelocity strafe, AngularVelocity manualRotate, Rotation2d robotHeading)
+    {
+        if (Math.abs(_driver.getTwist()) > DriveConstants.SNAKE_ROTATION_OVERRIDE_AXIS_DEADBAND)
+        {
+            resetSnakeMode(robotHeading);
+            return manualRotate;
+        }
+
+        var translationMagnitude = Math.hypot(drive.in(MetersPerSecond), strafe.in(MetersPerSecond));
+
+        if (translationMagnitude > DriveConstants.SNAKE_MIN_TRANSLATE_FOR_HEADING.in(MetersPerSecond))
+        {
+            var desiredHeadingRadians = Math.atan2(strafe.in(MetersPerSecond), drive.in(MetersPerSecond))
+                    + DriveConstants.SNAKE_INTAKE_HEADING_OFFSET.in(Radians);
+            _snakeHeading = Rotation2d.fromRadians(MathUtil.angleModulus(desiredHeadingRadians));
+        }
+
+        return RadiansPerSecond.of(_snakeController.calculate(robotHeading.getRadians(), _snakeHeading.getRadians()));
+    }
+
+    private void resetSnakeMode(Rotation2d robotHeading)
+    {
+        _snakeHeading = robotHeading;
+        _snakeController.reset(robotHeading.getRadians(), _drive.getState().Speeds.omegaRadiansPerSecond);
+    }
+
+    private void setManualFlywheelRPM(double rpm)
+    {
+        _manualFlywheelRPM = Math.max(0.0, rpm);
+        _shooter.setManualFlywheel(_manualFlywheelRPM);
+    }
+
     private void configureBindings()
     {
-        // Note that X is defined as forward according to WPILib convention,
-        // and Y is defined as to the left according to WPILib convention.
-        _drive.setDefaultCommand(
-                // Drivetrain will execute this command periodically
-                _drive.applyRequest(() -> _fieldCentric.withVelocityX(getDrive()).withVelocityY(getStrafe()).withRotationalRate(getRotate()))
-        );
+        _drive.setDefaultCommand(_drive.applyRequest(this::getFieldCentricRequest));
 
         final var idle = new SwerveRequest.Idle();
         RobotModeTriggers.disabled().whileTrue(_drive.applyRequest(() -> idle).ignoringDisable(true));
 
-        _driver.button(1).whileTrue(Commands.either(_shooter.manualShoot(), _shooter.shoot(), _shooter::inManualMode));
+        _driver.button(1).whileTrue(_shooter.shoot());
         _driver.button(2).whileTrue(Commands.startEnd(() -> _driveMultiplier = DriveConstants.SLOW_MODE_SCALE, () -> _driveMultiplier = DriveConstants.FULL_SPEED_SCALE));
         _driver.button(3).whileTrue(_drive.applyRequest(() -> _robotCentric.withVelocityX(getDrive()).withVelocityY(getStrafe()).withRotationalRate(getRotate())));
         _driver.button(5).whileTrue(_shooter.pass());
@@ -88,19 +166,14 @@ public class RobotContainer
         _operator.leftTrigger().whileTrue(_intake.runRollersForward());
         _operator.leftBumper().whileTrue(_intake.runRollersReverse());
         _operator.rightTrigger().whileTrue(_intake.jiggle());
-        _operator.povDown().onTrue(_intake.getRetractCmd());
-        _operator.povUp().onTrue(_intake.getExtendCmd());
-
-        // start and back enables manual mode
-        // start without back enables auto mode
         _operator.start().and(_operator.back()).onTrue(_shooter.setManualMode(true));
         _operator.start().and(_operator.back().negate()).onTrue(_shooter.setManualMode(false));
-
-        _operator.y().onTrue(_shooter.setFlywheelVelocity(ShooterConstants.MANUAL_SHOOT_RPM));
-        _operator.b().onTrue(_shooter.modFlywheelVelocity(RPM.of(100)));
-        _operator.x().onTrue(_shooter.modFlywheelVelocity(RPM.of(-100)));
-        _operator.a().onTrue(_shooter.stopFlywheel());
-        _operator.rightBumper().whileTrue(_shooter.runFeeder());
+        _operator.y().onTrue(Commands.runOnce(() -> setManualFlywheelRPM(MANUAL_FLYWHEEL_START_RPM)).onlyIf(_shooter::inManualMode));
+        _operator.x().onTrue(Commands.runOnce(() -> setManualFlywheelRPM(_manualFlywheelRPM - MANUAL_FLYWHEEL_STEP_RPM)).onlyIf(_shooter::inManualMode));
+        _operator.b().onTrue(Commands.runOnce(() -> setManualFlywheelRPM(_manualFlywheelRPM + MANUAL_FLYWHEEL_STEP_RPM)).onlyIf(_shooter::inManualMode));
+        _operator.a().onTrue(Commands.runOnce(_shooter::stopManualFlywheel).onlyIf(_shooter::inManualMode));
+        _operator.povDown().onTrue(_intake.getRetractCmd());
+        _operator.povUp().onTrue(_intake.getExtendCmd());
     }
 
     public Command getAutonomousCommand()

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -321,22 +321,27 @@ public class Drive extends TunerSwerveDrivetrain implements Subsystem
     @Logged
     public class DriveVision
     {
+        private static final Pose2d          kInvalidVisionPose   = new Pose2d(-1.0, -1.0, Rotation2d.kZero);
         private final Limelight              _limelightLeft;
         private final Limelight              _limelightRight;
         private final LimelightPoseEstimator _poseEstimatorLeft;
         private final LimelightPoseEstimator _poseEstimatorRight;
         @Logged
-        private double                       _lastTimestampLeft  = 0.0;
+        private double                       _lastTimestampLeft   = 0.0;
         @Logged
-        private double                       _lastTimestampRight = 0.0;
+        private double                       _lastTimestampRight  = 0.0;
         @Logged
-        private boolean                      _hasVisionLeft      = false;
+        private boolean                      _hasVisionLeft       = false;
         @Logged
-        private boolean                      _hasVisionRight     = false;
+        private boolean                      _hasVisionRight      = false;
         @Logged
-        private Pose2d                       _leftPose           = new Pose2d();
+        private boolean                      _acceptedVisionLeft  = false;
         @Logged
-        private Pose2d                       _rightPose          = new Pose2d();
+        private boolean                      _acceptedVisionRight = false;
+        @Logged
+        private Pose2d                       _leftPose            = kInvalidVisionPose;
+        @Logged
+        private Pose2d                       _rightPose           = kInvalidVisionPose;
 
         public DriveVision()
         {
@@ -365,16 +370,17 @@ public class Drive extends TunerSwerveDrivetrain implements Subsystem
         {
             if (RobotBase.isSimulation()) return;
 
-            _hasVisionLeft  = processLimelight(_limelightLeft, _poseEstimatorLeft, _lastTimestampLeft);
-            _hasVisionRight = processLimelight(_limelightRight, _poseEstimatorRight, _lastTimestampRight);
+            _acceptedVisionLeft  = processLimelight(_limelightLeft, _poseEstimatorLeft, _lastTimestampLeft, true);
+            _acceptedVisionRight = processLimelight(_limelightRight, _poseEstimatorRight, _lastTimestampRight, false);
         }
 
-        private boolean processLimelight(Limelight limelight, LimelightPoseEstimator poseEstimator, double lastTimestamp)
+        private boolean processLimelight(Limelight limelight, LimelightPoseEstimator poseEstimator, double lastTimestamp, boolean isLeft)
         {
             var results = limelight.getLatestResults();
 
             if (results.isEmpty() || results.get().targets_Fiducials.length <= 0)
             {
+                setVisionState(isLeft, false, kInvalidVisionPose);
                 return false;
             }
 
@@ -382,16 +388,12 @@ public class Drive extends TunerSwerveDrivetrain implements Subsystem
 
             if (estimate.isEmpty())
             {
+                setVisionState(isLeft, false, kInvalidVisionPose);
                 return false;
             }
 
             PoseEstimate poseEstimate = estimate.get();
-            if (poseEstimate.timestampSeconds <= lastTimestamp)
-            {
-                return false;
-            }
-
-            var pose = poseEstimate.pose.toPose2d();
+            var          pose         = poseEstimate.pose.toPose2d();
 
             // Somehow, bad data can still get through here
             // check for a zero pose and throw it out
@@ -399,23 +401,43 @@ public class Drive extends TunerSwerveDrivetrain implements Subsystem
 
             if (Math.abs(pose.getX()) < 1e-6 && Math.abs(pose.getY()) < 1e-6)
             {
+                setVisionState(isLeft, false, kInvalidVisionPose);
+                return false;
+            }
+
+            setVisionState(isLeft, true, pose);
+
+            if (poseEstimate.timestampSeconds <= lastTimestamp)
+            {
                 return false;
             }
 
             addVisionMeasurement(pose, poseEstimate.timestampSeconds);
 
-            if (limelight == _limelightLeft)
+            if (isLeft)
             {
                 _lastTimestampLeft = poseEstimate.timestampSeconds;
-                _leftPose          = pose;
             }
             else
             {
                 _lastTimestampRight = poseEstimate.timestampSeconds;
-                _rightPose          = pose;
             }
 
             return true;
+        }
+
+        private void setVisionState(boolean isLeft, boolean hasVision, Pose2d pose)
+        {
+            if (isLeft)
+            {
+                _hasVisionLeft = hasVision;
+                _leftPose      = pose;
+            }
+            else
+            {
+                _hasVisionRight = hasVision;
+                _rightPose      = pose;
+            }
         }
     }
 }

--- a/src/main/java/frc/robot/subsystems/drive/Drive.java
+++ b/src/main/java/frc/robot/subsystems/drive/Drive.java
@@ -14,7 +14,9 @@ import com.ctre.phoenix6.swerve.SwerveRequest;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.wpilibj.DriverStation;
@@ -31,6 +33,9 @@ import frc.robot.subsystems.drive.TunerConstants.TunerSwerveDrivetrain;
 import limelight.Limelight;
 import limelight.networktables.LimelightPoseEstimator;
 import limelight.networktables.LimelightPoseEstimator.EstimationMode;
+import limelight.networktables.LimelightSettings;
+import limelight.networktables.LimelightSettings.ImuMode;
+import limelight.networktables.Orientation3d;
 import limelight.networktables.PoseEstimate;
 
 /**
@@ -321,47 +326,53 @@ public class Drive extends TunerSwerveDrivetrain implements Subsystem
     @Logged
     public class DriveVision
     {
-        private static final Pose2d          kInvalidVisionPose   = new Pose2d(-1.0, -1.0, Rotation2d.kZero);
-        private final Limelight              _limelightLeft;
-        private final Limelight              _limelightRight;
-        private final LimelightPoseEstimator _poseEstimatorLeft;
-        private final LimelightPoseEstimator _poseEstimatorRight;
         @Logged
-        private double                       _lastTimestampLeft   = 0.0;
+        private final VisionState   _leftVision;
         @Logged
-        private double                       _lastTimestampRight  = 0.0;
-        @Logged
-        private boolean                      _hasVisionLeft       = false;
-        @Logged
-        private boolean                      _hasVisionRight      = false;
-        @Logged
-        private boolean                      _acceptedVisionLeft  = false;
-        @Logged
-        private boolean                      _acceptedVisionRight = false;
-        @Logged
-        private Pose2d                       _leftPose            = kInvalidVisionPose;
-        @Logged
-        private Pose2d                       _rightPose           = kInvalidVisionPose;
+        private final VisionState   _rightVision;
+        private static final Pose2d kInvalidVisionPose = new Pose2d(-1.0, -1.0, Rotation2d.kZero);
+
+        public static final class VisionState
+        {
+            @Logged
+            private double                       _lastTimestamp  = 0.0;
+            @Logged
+            private boolean                      _hasVision      = false;
+            @Logged
+            private boolean                      _acceptedVision = false;
+            @Logged
+            private Pose2d                       _pose           = kInvalidVisionPose;
+            private final Limelight              _limelight;
+            private final LimelightSettings      _settings;
+            private final LimelightPoseEstimator _poseEstimator;
+
+            private VisionState(Limelight limelight, Pose3d cameraOffset)
+            {
+                _limelight = limelight;
+                if (_limelight == null)
+                {
+                    _settings      = null;
+                    _poseEstimator = null;
+                    return;
+                }
+
+                _settings = _limelight.getSettings();
+                _settings.withCameraOffset(cameraOffset).save();
+                _poseEstimator = _limelight.createPoseEstimator(EstimationMode.MEGATAG2);
+            }
+        }
 
         public DriveVision()
         {
             if (RobotBase.isReal())
             {
-                _limelightLeft  = new Limelight(VisionConstants.LEFT_CAMERA_NAME);
-                _limelightRight = new Limelight(VisionConstants.RIGHT_CAMERA_NAME);
-
-                _poseEstimatorLeft  = _limelightLeft.createPoseEstimator(EstimationMode.MEGATAG1);
-                _poseEstimatorRight = _limelightRight.createPoseEstimator(EstimationMode.MEGATAG1);
-
-                _limelightLeft.getSettings().withCameraOffset(VisionConstants.LEFT_CAMERA_OFFSET).save();
-                _limelightRight.getSettings().withCameraOffset(VisionConstants.RIGHT_CAMERA_OFFSET).save();
+                _leftVision  = new VisionState(new Limelight(VisionConstants.LEFT_CAMERA_NAME), VisionConstants.LEFT_CAMERA_OFFSET);
+                _rightVision = new VisionState(new Limelight(VisionConstants.RIGHT_CAMERA_NAME), VisionConstants.RIGHT_CAMERA_OFFSET);
             }
             else
             {
-                _limelightLeft      = null;
-                _limelightRight     = null;
-                _poseEstimatorLeft  = null;
-                _poseEstimatorRight = null;
+                _leftVision  = new VisionState(null, null);
+                _rightVision = new VisionState(null, null);
             }
             setVisionMeasurementStdDevs(VisionConstants.STD_DEVS);
         }
@@ -370,25 +381,44 @@ public class Drive extends TunerSwerveDrivetrain implements Subsystem
         {
             if (RobotBase.isSimulation()) return;
 
-            _acceptedVisionLeft  = processLimelight(_limelightLeft, _poseEstimatorLeft, _lastTimestampLeft, true);
-            _acceptedVisionRight = processLimelight(_limelightRight, _poseEstimatorRight, _lastTimestampRight, false);
+            var robotHeading                 = getState().Pose.getRotation();
+            var robotYawRateDegreesPerSecond = Math.toDegrees(getState().Speeds.omegaRadiansPerSecond);
+            var imuMode                      = DriverStation.isDisabled() ? ImuMode.SyncInternalImu : ImuMode.InternalImuExternalAssist;
+            setRobotOrientation(_leftVision, robotHeading, robotYawRateDegreesPerSecond, imuMode);
+            setRobotOrientation(_rightVision, robotHeading, robotYawRateDegreesPerSecond, imuMode);
+
+            _leftVision._acceptedVision  = processLimelight(_leftVision);
+            _rightVision._acceptedVision = processLimelight(_rightVision);
         }
 
-        private boolean processLimelight(Limelight limelight, LimelightPoseEstimator poseEstimator, double lastTimestamp, boolean isLeft)
+        private void setRobotOrientation(VisionState state, Rotation2d robotHeading, double robotYawRateDegreesPerSecond, ImuMode imuMode)
         {
-            var results = limelight.getLatestResults();
+            state._settings.withImuMode(imuMode)
+                    .withRobotOrientation(new Orientation3d(new Rotation3d(Degrees.zero(), Degrees.zero(), robotHeading.getMeasure()), DegreesPerSecond.zero(), DegreesPerSecond.zero(), DegreesPerSecond.of(robotYawRateDegreesPerSecond)))
+                    .save();
+        }
 
-            if (results.isEmpty() || results.get().targets_Fiducials.length <= 0)
+        private boolean processLimelight(VisionState state)
+        {
+            if (Math.abs(Math.toDegrees(getState().Speeds.omegaRadiansPerSecond)) > VisionConstants.MAX_ANGULAR_RATE_FOR_VISION.in(DegreesPerSecond))
             {
-                setVisionState(isLeft, false, kInvalidVisionPose);
+                setVisionState(state, false, kInvalidVisionPose);
                 return false;
             }
 
-            Optional<PoseEstimate> estimate = poseEstimator.getPoseEstimate();
+            var results = state._limelight.getLatestResults();
+
+            if (results.isEmpty() || results.get().targets_Fiducials.length <= 0)
+            {
+                setVisionState(state, false, kInvalidVisionPose);
+                return false;
+            }
+
+            Optional<PoseEstimate> estimate = state._poseEstimator.getPoseEstimate();
 
             if (estimate.isEmpty())
             {
-                setVisionState(isLeft, false, kInvalidVisionPose);
+                setVisionState(state, false, kInvalidVisionPose);
                 return false;
             }
 
@@ -401,43 +431,29 @@ public class Drive extends TunerSwerveDrivetrain implements Subsystem
 
             if (Math.abs(pose.getX()) < 1e-6 && Math.abs(pose.getY()) < 1e-6)
             {
-                setVisionState(isLeft, false, kInvalidVisionPose);
+                setVisionState(state, false, kInvalidVisionPose);
                 return false;
             }
 
-            setVisionState(isLeft, true, pose);
+            // Keep hasVision/pose telemetry current even if this frame is stale and not
+            // fused.
+            setVisionState(state, true, pose);
 
-            if (poseEstimate.timestampSeconds <= lastTimestamp)
+            if (poseEstimate.timestampSeconds <= state._lastTimestamp)
             {
                 return false;
             }
 
             addVisionMeasurement(pose, poseEstimate.timestampSeconds);
-
-            if (isLeft)
-            {
-                _lastTimestampLeft = poseEstimate.timestampSeconds;
-            }
-            else
-            {
-                _lastTimestampRight = poseEstimate.timestampSeconds;
-            }
+            state._lastTimestamp = poseEstimate.timestampSeconds;
 
             return true;
         }
 
-        private void setVisionState(boolean isLeft, boolean hasVision, Pose2d pose)
+        private void setVisionState(VisionState state, boolean hasVision, Pose2d pose)
         {
-            if (isLeft)
-            {
-                _hasVisionLeft = hasVision;
-                _leftPose      = pose;
-            }
-            else
-            {
-                _hasVisionRight = hasVision;
-                _rightPose      = pose;
-            }
+            state._hasVision = hasVision;
+            state._pose      = pose;
         }
     }
 }

--- a/src/main/java/frc/robot/subsystems/drive/TunerConstants.java
+++ b/src/main/java/frc/robot/subsystems/drive/TunerConstants.java
@@ -47,7 +47,7 @@ public class TunerConstants
 
     // The stator current at which the wheels start to slip;
     // This needs to be tuned to your individual robot
-    private static final Current kSlipCurrent = Amps.of(100);
+    private static final Current kSlipCurrent = Amps.of(80);
 
     // Initial configs for the drive and steer motors and the azimuth encoder; these
     // cannot be null.

--- a/src/main/java/frc/robot/subsystems/shooter/Flywheel.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Flywheel.java
@@ -49,10 +49,6 @@ public class Flywheel
     private AngularVelocity                 _targetVelocity  = RPM.zero();
     @Logged
     private Voltage                         _flywheelVoltage = Volts.zero();
-    @Logged
-    private double                          _actualRpm       = 0.0;
-    @Logged
-    private double                          _targetRpm       = 0.0;
 
     public Flywheel()
     {
@@ -96,8 +92,6 @@ public class Flywheel
     {
         _velocity        = RPM.of(_flywheelEncoder.getVelocity());
         _flywheelVoltage = Volts.of(_leadMotor.getAppliedOutput() * _leadMotor.getBusVoltage());
-        _actualRpm       = _velocity.in(RPM);
-        _targetRpm       = _targetVelocity.in(RPM);
     }
 
     public void simulationPeriodic()

--- a/src/main/java/frc/robot/subsystems/shooter/Flywheel.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Flywheel.java
@@ -49,6 +49,10 @@ public class Flywheel
     private AngularVelocity                 _targetVelocity  = RPM.zero();
     @Logged
     private Voltage                         _flywheelVoltage = Volts.zero();
+    @Logged
+    private double                          _actualRpm       = 0.0;
+    @Logged
+    private double                          _targetRpm       = 0.0;
 
     public Flywheel()
     {
@@ -92,6 +96,8 @@ public class Flywheel
     {
         _velocity        = RPM.of(_flywheelEncoder.getVelocity());
         _flywheelVoltage = Volts.of(_leadMotor.getAppliedOutput() * _leadMotor.getBusVoltage());
+        _actualRpm       = _velocity.in(RPM);
+        _targetRpm       = _targetVelocity.in(RPM);
     }
 
     public void simulationPeriodic()

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -7,6 +7,7 @@ import java.util.function.Supplier;
 import com.ctre.phoenix6.swerve.SwerveDrivetrain.SwerveDriveState;
 
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -115,6 +116,29 @@ public class Shooter extends SubsystemBase
         })
         .onlyIf(this::inManualMode);
         // @formatter:on
+    }
+
+    public Command setFlywheelVelocity(AngularVelocity velocity)
+    {
+        return runOnce(() ->
+        {
+            _state = ShooterState.Manual;
+            _flywheel.setVelocity(velocity);
+        });
+    }
+
+    public Command runFeeder()
+    {
+        return startEnd(() ->
+        {
+            _state = ShooterState.Manual;
+            _feeder.set(true);
+        }, () ->
+        {
+            _feeder.set(false);
+            _flywheel.stop();
+            _state = ShooterState.Idle;
+        });
     }
 
     public Command stop()

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -1,11 +1,12 @@
 package frc.robot.subsystems.shooter;
 
+import static edu.wpi.first.units.Units.RPM;
+
 import java.util.function.Supplier;
 
 import com.ctre.phoenix6.swerve.SwerveDrivetrain.SwerveDriveState;
 
 import edu.wpi.first.epilogue.Logged;
-import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -17,15 +18,12 @@ public class Shooter extends SubsystemBase
 {
     public enum ShooterState
     {
-        Idle, Preparing, Ready, Firing, Manual
+        Idle, Preparing, Ready, Firing, Manual;
     }
 
-    /************
-     * COMMANDS *
-     ************/
     public Command startShooter()
     {
-        return runOnce(() -> startShoot(false));
+        return runOnce(() -> startPreparedShoot(false));
     }
 
     public Command fire()
@@ -35,7 +33,7 @@ public class Shooter extends SubsystemBase
 
     public Command shoot()
     {
-        return startEnd(() -> startShoot(true), () -> stopShooter());
+        return startEnd(this::startShoot, this::stopShooter);
     }
 
     public Command startPass()
@@ -45,42 +43,45 @@ public class Shooter extends SubsystemBase
 
     public Command pass()
     {
-        return startEnd(() -> startPass(true), () -> stopShooter());
+        return startEnd(() -> startPass(true), this::stopShooter);
     }
 
-    public Command stop()
-    {
-        return runOnce(this::stopShooter);
-    }
-
-    // Manual commands below
     public Command setManualMode(boolean manual)
     {
         return runOnce(() ->
         {
-            _state = manual ? ShooterState.Manual : ShooterState.Idle;
+            _state            = manual ? ShooterState.Manual : ShooterState.Idle;
+            _autoShootEnabled = false;
+            _feeder.set(false);
+            _turret.setTurretState(TurretState.Idle);
             _turret.setDisabled(manual);
+
+            if (manual)
+            {
+                _flywheel.stop();
+            }
         });
     }
 
-    public Command setFlywheelVelocity(AngularVelocity velocity)
+    public boolean inManualMode()
     {
-        return runOnce(() -> _flywheel.setVelocity(velocity)).onlyIf(this::inManualMode);
+        return _state == ShooterState.Manual;
     }
 
-    public Command modFlywheelVelocity(AngularVelocity mod)
+    public void setManualFlywheel(double rpm)
     {
-        return runOnce(() -> _flywheel.setVelocity(_flywheel.getTargetVelocity().plus(mod))).onlyIf(this::inManualMode);
+        if (inManualMode())
+        {
+            _flywheel.setVelocity(RPM.of(Math.max(0.0, rpm)));
+        }
     }
 
-    public Command stopFlywheel()
+    public void stopManualFlywheel()
     {
-        return runOnce(() -> _flywheel.stop()).onlyIf(this::inManualMode);
-    }
-
-    public Command runFeeder()
-    {
-        return startEnd(() -> _feeder.set(true), () -> _feeder.set(false)).onlyIf(this::inManualMode);
+        if (inManualMode())
+        {
+            _flywheel.stop();
+        }
     }
 
     public Command runRotor()
@@ -116,9 +117,11 @@ public class Shooter extends SubsystemBase
         // @formatter:on
     }
 
-    /*************
-     * SUBSYSTEM *
-     *************/
+    public Command stop()
+    {
+        return runOnce(this::stopShooter);
+    }
+
     public final Flywheel _flywheel;
     public final Feeder   _feeder;
     public final Turret   _turret;
@@ -134,14 +137,14 @@ public class Shooter extends SubsystemBase
         _feeder           = new Feeder();
         _turret           = new Turret(swerveStateSupplier);
         _rotor            = new Rotor();
-        _state            = ShooterState.Manual;
+        _state            = ShooterState.Idle;
         _autoShootEnabled = false;
 
         _feeder.set(false);
         _rotor.set(false);
         _flywheel.stop();
         _turret.setTurretState(TurretState.Idle);
-        _turret.setDisabled(true);
+        _turret.setDisabled(false);
     }
 
     @Override
@@ -179,9 +182,6 @@ public class Shooter extends SubsystemBase
                 break;
 
             case Manual:
-                // Do nothing. The different parts of the
-                // shooter will be controlled directly through
-                // commands
                 break;
 
             case Idle:
@@ -192,6 +192,8 @@ public class Shooter extends SubsystemBase
                 _turret.setTurretState(TurretState.Idle);
                 break;
         }
+
+        _feeder.set(_state == ShooterState.Firing);
 
         _turret.periodic();
         _flywheel.periodic();
@@ -205,7 +207,7 @@ public class Shooter extends SubsystemBase
         _flywheel.simulationPeriodic();
     }
 
-    public void startShoot(boolean autoShoot)
+    public void startPreparedShoot(boolean autoShoot)
     {
         beginShootingSequence(TurretState.Track, autoShoot);
     }
@@ -217,8 +219,9 @@ public class Shooter extends SubsystemBase
 
     private void beginShootingSequence(TurretState turretState, boolean autoShoot)
     {
-        if (_state == ShooterState.Idle)
+        if (_state == ShooterState.Idle || _state == ShooterState.Manual)
         {
+            _turret.setDisabled(false);
             _turret.setTurretState(turretState);
             _autoShootEnabled = autoShoot;
             _state            = ShooterState.Preparing;
@@ -229,6 +232,7 @@ public class Shooter extends SubsystemBase
     {
         _state            = ShooterState.Idle;
         _autoShootEnabled = false;
+        _turret.setDisabled(false);
     }
 
     public void commenceFiring()
@@ -239,6 +243,17 @@ public class Shooter extends SubsystemBase
         }
     }
 
+    private void startShoot()
+    {
+        if (_state == ShooterState.Idle || _state == ShooterState.Manual)
+        {
+            _turret.setDisabled(false);
+            _turret.setTurretState(TurretState.Track);
+            _autoShootEnabled = false;
+            _state            = ShooterState.Firing;
+        }
+    }
+
     private void primeShot()
     {
         if (_state != ShooterState.Idle)
@@ -246,10 +261,5 @@ public class Shooter extends SubsystemBase
             var distance = _turret.getTargetDistance();
             _flywheel.setVelocity(ShooterConstants.getFlywheelSpeedForDistance(distance));
         }
-    }
-
-    public boolean inManualMode()
-    {
-        return _state == ShooterState.Manual;
     }
 }

--- a/src/main/java/frc/robot/subsystems/shooter/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Shooter.java
@@ -34,7 +34,7 @@ public class Shooter extends SubsystemBase
 
     public Command shoot()
     {
-        return startEnd(this::startShoot, this::stopShooter);
+        return startEnd(() -> startPreparedShoot(true), this::stopShooter);
     }
 
     public Command startPass()
@@ -127,6 +127,11 @@ public class Shooter extends SubsystemBase
         });
     }
 
+    public Command runManualFeeder()
+    {
+        return startEnd(() -> _feeder.set(true), () -> _feeder.set(false)).onlyIf(this::inManualMode);
+    }
+
     public Command runFeeder()
     {
         return startEnd(() ->
@@ -182,7 +187,7 @@ public class Shooter extends SubsystemBase
                 _rotor.set(false);
                 primeShot();
 
-                if (_flywheel.atSpeed() && _turret.isLinedUp())
+                if (isReadyToFeed())
                 {
                     if (_autoShootEnabled)
                     {
@@ -203,6 +208,15 @@ public class Shooter extends SubsystemBase
                 _feeder.set(true);
                 _rotor.set(true);
                 primeShot();
+                if (isReadyToFeed())
+                {
+                    _feeder.set(true);
+                }
+                else
+                {
+                    _feeder.set(false);
+                    _state = ShooterState.Preparing;
+                }
                 break;
 
             case Manual:
@@ -216,8 +230,6 @@ public class Shooter extends SubsystemBase
                 _turret.setTurretState(TurretState.Idle);
                 break;
         }
-
-        _feeder.set(_state == ShooterState.Firing);
 
         _turret.periodic();
         _flywheel.periodic();
@@ -243,13 +255,11 @@ public class Shooter extends SubsystemBase
 
     private void beginShootingSequence(TurretState turretState, boolean autoShoot)
     {
-        if (_state == ShooterState.Idle || _state == ShooterState.Manual)
-        {
-            _turret.setDisabled(false);
-            _turret.setTurretState(turretState);
-            _autoShootEnabled = autoShoot;
-            _state            = ShooterState.Preparing;
-        }
+        _feeder.set(false);
+        _turret.setDisabled(false);
+        _turret.setTurretState(turretState);
+        _autoShootEnabled = autoShoot;
+        _state            = ShooterState.Preparing;
     }
 
     public void stopShooter()
@@ -267,17 +277,6 @@ public class Shooter extends SubsystemBase
         }
     }
 
-    private void startShoot()
-    {
-        if (_state == ShooterState.Idle || _state == ShooterState.Manual)
-        {
-            _turret.setDisabled(false);
-            _turret.setTurretState(TurretState.Track);
-            _autoShootEnabled = false;
-            _state            = ShooterState.Firing;
-        }
-    }
-
     private void primeShot()
     {
         if (_state != ShooterState.Idle)
@@ -285,5 +284,10 @@ public class Shooter extends SubsystemBase
             var distance = _turret.getTargetDistance();
             _flywheel.setVelocity(ShooterConstants.getFlywheelSpeedForDistance(distance));
         }
+    }
+
+    private boolean isReadyToFeed()
+    {
+        return _flywheel.atSpeed();
     }
 }

--- a/src/main/java/frc/robot/subsystems/shooter/Turret.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Turret.java
@@ -179,6 +179,7 @@ public class Turret
                     _limelightDistance  = ShooterConstants.TURRET_TO_HUB_HEIGHT_DELTA.div(Math.tan(tyMeasure.plus(ShooterConstants.TURRET_LIMELIGHT_PITCH).in(Radians)));
                     _limelightHasTarget = true;
 
+                    // Ignore tiny Limelight yaw error so we don't keep hunting on vision noise.
                     if (!MathUtil.isNear(0.0, txCorrection.in(Degrees), ShooterConstants.TURRET_TRACK_TX_DEADBAND.in(Degrees)))
                     {
                         rawSetpoint = rawSetpoint.minus(txCorrection);

--- a/src/main/java/frc/robot/subsystems/shooter/Turret.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Turret.java
@@ -151,11 +151,11 @@ public class Turret
                     fiducials = results.get().targets_Fiducials;
                 }
 
-                var localHubTranslation    = getHubTranslationInRobotFrame();
+                var localHubTranslation = getHubTranslationInRobotFrame();
                 var turretToHubTranslation = localHubTranslation.minus(ShooterConstants.TURRET_POSITION);
 
                 _targetDistance = Meters.of(turretToHubTranslation.getNorm());
-                rawSetpoint     = getTurretSetpointForRobotFrameTarget(turretToHubTranslation);
+                rawSetpoint = getTurretSetpointForRobotFrameTarget(turretToHubTranslation);
 
                 if (fiducials.length > 0)
                 {

--- a/src/main/java/frc/robot/subsystems/shooter/Turret.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Turret.java
@@ -3,7 +3,6 @@ package frc.robot.subsystems.shooter;
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Meters;
-import static edu.wpi.first.units.Units.Radians;
 import static edu.wpi.first.units.Units.Volts;
 
 import java.util.List;
@@ -68,9 +67,9 @@ public class Turret
     @Logged
     private Pose2d                           _targetPose;
     @Logged
-    private Distance                         _limelightDistance;
-    @Logged
     private boolean                          _limelightHasTarget;
+    @Logged
+    private boolean                          _targetValid;
     @Logged
     private boolean                          _disabled;
 
@@ -99,8 +98,8 @@ public class Turret
         _motorVoltage       = Volts.zero();
         _targetDistance     = Meters.zero();
         _targetPose         = new Pose2d();
-        _limelightDistance  = Meters.zero();
         _limelightHasTarget = false;
+        _targetValid        = false;
         _disabled           = false;
 
         var currentConfig = new CurrentLimitsConfigs();
@@ -134,7 +133,7 @@ public class Turret
         _turretAngle        = Degrees.of(_turretSensor.get());
         _motorVoltage       = _turretMotor.getMotorVoltage().getValue();
         _limelightHasTarget = false;
-        _limelightDistance  = Meters.zero();
+        _targetValid        = false;
 
         var fiducials   = new AprilTagFiducial[0];
         var motorOutput = Volts.zero();
@@ -157,27 +156,25 @@ public class Turret
                 _targetDistance = Meters.of(turretToHubTranslation.getNorm());
                 rawSetpoint = getTurretSetpointForRobotFrameTarget(turretToHubTranslation);
 
-                if (fiducials.length > 0)
-                {
-                    double avgTx = 0.0;
-                    double avgTy = 0.0;
+                AprilTagFiducial bestTag = null;
 
-                    for (AprilTagFiducial tag : fiducials)
+                for (AprilTagFiducial tag : fiducials)
+                {
+                    if (!Utilities.getOurHubTagIds().contains(tag.fiducialID))
                     {
-                        avgTx -= tag.tx;
-                        avgTy -= tag.ty;
+                        continue;
                     }
 
-                    int n = fiducials.length;
+                    if (bestTag == null || tag.ta > bestTag.ta || tag.ta == bestTag.ta && Math.abs(tag.tx) < Math.abs(bestTag.tx))
+                    {
+                        bestTag = tag;
+                    }
+                }
 
-                    avgTx /= n;
-                    avgTy /= n;
-
-                    var tyMeasure    = Degrees.of(avgTy);
-                    var txCorrection = Degrees.of(avgTx);
-
-                    _limelightDistance  = ShooterConstants.TURRET_TO_HUB_HEIGHT_DELTA.div(Math.tan(tyMeasure.plus(ShooterConstants.TURRET_LIMELIGHT_PITCH).in(Radians)));
+                if (bestTag != null)
+                {
                     _limelightHasTarget = true;
+                    var txCorrection = Degrees.of(-bestTag.tx);
 
                     // Ignore tiny Limelight yaw error so we don't keep hunting on vision noise.
                     if (!MathUtil.isNear(0.0, txCorrection.in(Degrees), ShooterConstants.TURRET_TRACK_TX_DEADBAND.in(Degrees)))
@@ -185,10 +182,13 @@ public class Turret
                         rawSetpoint = rawSetpoint.minus(txCorrection);
                     }
                 }
+
+                _targetValid = Utilities.isHubActive();
                 break;
 
             case Pass:
                 _hasSetpoint = true;
+                _targetValid = true;
                 Angle fieldTargetAngle;
 
                 if (Utilities.isBlueAlliance())
@@ -208,6 +208,7 @@ public class Turret
             case Idle:
             default:
                 _hasSetpoint = false;
+                _targetValid = false;
                 rawSetpoint = ShooterConstants.TURRET_HOME_ANGLE;
                 _targetDistance = Meters.zero();
                 break;
@@ -251,6 +252,16 @@ public class Turret
     public boolean isLinedUp()
     {
         return _hasSetpoint && _pidController.atSetpoint();
+    }
+
+    public boolean hasValidTarget()
+    {
+        return _targetValid;
+    }
+
+    public boolean isReadyToShoot()
+    {
+        return hasValidTarget() && isLinedUp();
     }
 
     public void setDisabled(boolean disabled)

--- a/src/main/java/frc/robot/subsystems/shooter/Turret.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Turret.java
@@ -160,6 +160,7 @@ public class Turret
 
                 for (AprilTagFiducial tag : fiducials)
                 {
+                    // Limelight reports the tag ID as a double, but our tag lists are ints.
                     var tagId = (int)Math.round(tag.fiducialID);
 
                     if (!Utilities.getOurHubTagIds().contains(tagId))
@@ -288,15 +289,12 @@ public class Turret
 
     private Voltage applySoftLimit(Voltage requestedVoltage)
     {
-        var requestedVolts = requestedVoltage.in(Volts);
-        var turretDegrees  = _turretAngle.in(Degrees);
-
-        if (turretDegrees <= ShooterConstants.TURRET_SOFT_MIN_ANGLE.in(Degrees) && requestedVolts < 0.0)
+        if (_turretAngle.lte(ShooterConstants.TURRET_SOFT_MIN_ANGLE) && requestedVoltage.lt(Volts.zero()))
         {
             return Volts.zero();
         }
 
-        if (turretDegrees >= ShooterConstants.TURRET_SOFT_MAX_ANGLE.in(Degrees) && requestedVolts > 0.0)
+        if (_turretAngle.gte(ShooterConstants.TURRET_SOFT_MAX_ANGLE) && requestedVoltage.gt(Volts.zero()))
         {
             return Volts.zero();
         }

--- a/src/main/java/frc/robot/subsystems/shooter/Turret.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Turret.java
@@ -68,6 +68,10 @@ public class Turret
     @Logged
     private Pose2d                           _targetPose;
     @Logged
+    private Distance                         _limelightDistance;
+    @Logged
+    private boolean                          _limelightHasTarget;
+    @Logged
     private boolean                          _disabled;
 
     public Turret(Supplier<SwerveDriveState> swerveStateSupplier)
@@ -95,6 +99,8 @@ public class Turret
         _motorVoltage       = Volts.zero();
         _targetDistance     = Meters.zero();
         _targetPose         = new Pose2d();
+        _limelightDistance  = Meters.zero();
+        _limelightHasTarget = false;
         _disabled           = false;
 
         var currentConfig = new CurrentLimitsConfigs();
@@ -125,8 +131,10 @@ public class Turret
     {
         _currentSwerveState = _swerveStateSupplier.get();
 
-        _turretAngle  = Degrees.of(_turretSensor.get());
-        _motorVoltage = _turretMotor.getMotorVoltage().getValue();
+        _turretAngle        = Degrees.of(_turretSensor.get());
+        _motorVoltage       = _turretMotor.getMotorVoltage().getValue();
+        _limelightHasTarget = false;
+        _limelightDistance  = Meters.zero();
 
         var fiducials   = new AprilTagFiducial[0];
         var motorOutput = Volts.zero();
@@ -143,26 +151,19 @@ public class Turret
                     fiducials = results.get().targets_Fiducials;
                 }
 
-                if (fiducials.length <= 0)
-                {
-                    var hub                  = Utilities.getHubCoordinates();
-                    var robot                = _currentSwerveState.Pose.getTranslation();
-                    var robotToHub           = hub.minus(robot);
-                    var robotAngleCorrection = _currentSwerveState.Pose.getRotation().getMeasure().plus(ShooterConstants.TURRET_ZERO_OFFSET_FROM_ROBOT_FORWARD);
+                var localHubTranslation    = getHubTranslationInRobotFrame();
+                var turretToHubTranslation = localHubTranslation.minus(ShooterConstants.TURRET_POSITION);
 
-                    _targetDistance = Meters.of(robotToHub.getNorm());
-                    rawSetpoint     = robotToHub.getAngle().getMeasure().minus(robotAngleCorrection);
-                }
-                else
+                _targetDistance = Meters.of(turretToHubTranslation.getNorm());
+                rawSetpoint     = getTurretSetpointForRobotFrameTarget(turretToHubTranslation);
+
+                if (fiducials.length > 0)
                 {
                     double avgTx = 0.0;
                     double avgTy = 0.0;
 
                     for (AprilTagFiducial tag : fiducials)
                     {
-                        // subtract the values instead of adding them
-                        // our limelight is mounted upside down so we
-                        // need the inverse of these measurements
                         avgTx -= tag.tx;
                         avgTy -= tag.ty;
                     }
@@ -172,11 +173,16 @@ public class Turret
                     avgTx /= n;
                     avgTy /= n;
 
-                    // Tx and Ty are now the average pitch and yaw to the target.
-                    // Now calculate distance from pitch
-                    var tyMeasure = Degrees.of(avgTy);
-                    _targetDistance = ShooterConstants.TURRET_TO_HUB_HEIGHT_DELTA.div(Math.tan(tyMeasure.plus(ShooterConstants.TURRET_LIMELIGHT_PITCH).in(Radians)));
-                    rawSetpoint     = _turretAngle.minus(Degrees.of(avgTx));
+                    var tyMeasure    = Degrees.of(avgTy);
+                    var txCorrection = Degrees.of(avgTx);
+
+                    _limelightDistance  = ShooterConstants.TURRET_TO_HUB_HEIGHT_DELTA.div(Math.tan(tyMeasure.plus(ShooterConstants.TURRET_LIMELIGHT_PITCH).in(Radians)));
+                    _limelightHasTarget = true;
+
+                    if (!MathUtil.isNear(0.0, txCorrection.in(Degrees), ShooterConstants.TURRET_TRACK_TX_DEADBAND.in(Degrees)))
+                    {
+                        rawSetpoint = rawSetpoint.minus(txCorrection);
+                    }
                 }
                 break;
 
@@ -200,7 +206,7 @@ public class Turret
 
             case Idle:
             default:
-                _hasSetpoint = true;
+                _hasSetpoint = false;
                 rawSetpoint = ShooterConstants.TURRET_HOME_ANGLE;
                 _targetDistance = Meters.zero();
                 break;
@@ -218,6 +224,7 @@ public class Turret
             motorOutput = Volts.of(_pidController.calculate(_turretAngle.in(Degrees), _turretSetpoint.in(Degrees)));
         }
 
+        motorOutput = applySoftLimit(motorOutput);
         _turretMotor.setVoltage(motorOutput.in(Volts));
     }
 
@@ -258,14 +265,40 @@ public class Turret
         }
     }
 
-    // Depending on the geometry of the field and where we need to shoot to,
-    // sometimes we might get an angle that's like -300 degrees. We can point
-    // to it (it's the same as 60 degrees), but MeasureUtil.clamp doesn't
-    // handle this rollover
     private Angle moduloAngle(Angle angle)
     {
         var degrees = angle.in(Degrees);
 
         return Degrees.of(MathUtil.inputModulus(degrees, -180, 180));
+    }
+
+    private Voltage applySoftLimit(Voltage requestedVoltage)
+    {
+        var requestedVolts = requestedVoltage.in(Volts);
+        var turretDegrees  = _turretAngle.in(Degrees);
+
+        if (turretDegrees <= ShooterConstants.TURRET_SOFT_MIN_ANGLE.in(Degrees) && requestedVolts < 0.0)
+        {
+            return Volts.zero();
+        }
+
+        if (turretDegrees >= ShooterConstants.TURRET_SOFT_MAX_ANGLE.in(Degrees) && requestedVolts > 0.0)
+        {
+            return Volts.zero();
+        }
+
+        return requestedVoltage;
+    }
+
+    private Translation2d getHubTranslationInRobotFrame()
+    {
+        var robotToHubField = Utilities.getHubCoordinates().minus(_currentSwerveState.Pose.getTranslation());
+
+        return robotToHubField.rotateBy(_currentSwerveState.Pose.getRotation().unaryMinus());
+    }
+
+    private Angle getTurretSetpointForRobotFrameTarget(Translation2d targetTranslation)
+    {
+        return targetTranslation.getAngle().getMeasure().minus(ShooterConstants.TURRET_ZERO_OFFSET_FROM_ROBOT_FORWARD);
     }
 }

--- a/src/main/java/frc/robot/subsystems/shooter/Turret.java
+++ b/src/main/java/frc/robot/subsystems/shooter/Turret.java
@@ -160,7 +160,9 @@ public class Turret
 
                 for (AprilTagFiducial tag : fiducials)
                 {
-                    if (!Utilities.getOurHubTagIds().contains(tag.fiducialID))
+                    var tagId = (int)Math.round(tag.fiducialID);
+
+                    if (!Utilities.getOurHubTagIds().contains(tagId))
                     {
                         continue;
                     }

--- a/src/main/java/frc/robot/subsystems/shooter/TurretDirector.java
+++ b/src/main/java/frc/robot/subsystems/shooter/TurretDirector.java
@@ -40,33 +40,31 @@ public class TurretDirector
                 }
                 else
                 {
-                    double avgTx = 0.0;
-                    double avgTy = 0.0;
+                    double invertedYawSumDegrees   = 0.0;
+                    double invertedPitchSumDegrees = 0.0;
 
                     for (AprilTagFiducial tag : fiducials)
                     {
-                        // subtract the values instead of adding them
-                        // our limelight is mounted upside down so we
-                        // need the inverse of these measurements
-                        avgTx -= tag.tx;
-                        avgTy -= tag.ty;
+                        // Limelight is mounted upside down, so invert tx/ty before averaging.
+                        invertedYawSumDegrees   -= tag.tx;
+                        invertedPitchSumDegrees -= tag.ty;
                     }
 
-                    int n = fiducials.length;
+                    int sampleCount = fiducials.length;
 
-                    avgTx /= n;
-                    avgTy /= n;
+                    double averageInvertedYawDegrees   = invertedYawSumDegrees / sampleCount;
+                    double averageInvertedPitchDegrees = invertedPitchSumDegrees / sampleCount;
 
                     // Tx and Ty are now the average pitch and yaw to the target.
                     // Now calculate distance from pitch
-                    var tyMeasure = Degrees.of(avgTy);
+                    var tyMeasure = Degrees.of(averageInvertedPitchDegrees);
                     var distance  = ShooterConstants.TURRET_TO_HUB_HEIGHT_DELTA.div(Math.tan(tyMeasure.plus(ShooterConstants.TURRET_LIMELIGHT_PITCH).in(Radians)));
 
                     // We have a distance and an angle. We can now describe the camera to target
                     // translation as a forward vector with magnitude "distance" rotated by angle
-                    // "avgTx"
+                    // "averageInvertedYawDegrees"
 
-                    var localCameraToTarget = new Translation2d(distance, Inches.zero()).rotateBy(Rotation2d.fromDegrees(-avgTx));
+                    var localCameraToTarget = new Translation2d(distance, Inches.zero()).rotateBy(Rotation2d.fromDegrees(-averageInvertedYawDegrees));
 
                     // now, calculate ret and account for the turret being offset and at an angle
                     // get translation from the center of the robot to the camera


### PR DESCRIPTION
This PR is basically a cleanup/improvement pass on the shooter + turret flow compared to `main`.

The main things I wanted to improve were:
- make the shooter sequence safer
- make turret targeting a little more robust
- make manual shooter testing less annoying
- clean up some vision-related behavior
- fix a couple branch issues before opening the PR

On the shooter side, this moves things more toward a real `Preparing -> Ready -> Firing` flow instead of just having the feeder/flywheel/turret behavior feel loosely connected. The biggest practical change there is that feeding is no longer based on flywheel speed alone — it now also requires the turret to actually be ready to shoot.

On the turret side, this keeps the pose-based hub aiming path and uses vision more like a trim instead of the whole solution. It also adds back soft-limit protection on turret output, which is important for not doing something dumb near the ends of travel.

For drive vision, this makes the pose rejection a little safer by ignoring empty / invalid / zeroed-out measurements and logging the state more clearly.

There are also some manual testing quality-of-life changes in here, mostly around the shooter controls, so it’s easier to use the branch for turret/flywheel testing without fighting the normal shoot flow.