### PR TITLE
CI Runners should use variables for what container and runner to use

### DIFF
--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -21,7 +21,6 @@ jobs:
     # The type of runner that the job will run on.  
     runs-on: ${{vars.RUNNER||'ubuntu-latest' }}
     # This grabs the WPILib docker container
-    # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     container: ${{vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04' }}
     steps:
   # THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings alongside the container

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -18,17 +18,16 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    #TODO: Add back  vars.RUNNER||
-    runs-on: ${{'ubuntu-latest' }}
+    # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings 
+    runs-on: ${{vars.RUNNER||'ubuntu-latest' }}
     # This grabs the WPILib docker container
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    # TODO add back: vars.CONTAINER||
-    container: ${{'wpilib/roborio-cross-ubuntu:2025-22.04' }}
+    container: ${{vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04' }}
     steps:
-    - name: Warn if not set
-      if: vars.RUNNER != 'ubuntu-latest'
-      run: echo "This step will be skipped on Monday and Wednesday"
+    #THIS ALWAYS RUNS, TODO FIX
+    - name: Warn if runner is not set
+      #if: vars.RUNNER == 'ubuntu-latest'
+      run: echo "::warning ::The RUNNER variable is not set" 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v6
     # Declares the repository safe and not under dubious ownership.

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     #THIS ALWAYS RUNS, TODO FIX
     - name: Warn if runner is not set
-      #if: vars.RUNNER == 'ubuntu-latest'
+      if: vars.RUNNER == 'ubuntu-latest'
       run: echo "::warning ::The RUNNER variable is not set" 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v6

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -19,11 +19,16 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    runs-on: ${{ vars.RUNNER||'ubuntu-22.04' }}
+    #TODO: Add back  vars.RUNNER||
+    runs-on: ${{'ubuntu-latest' }}
     # This grabs the WPILib docker container
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    container: ${{ vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04' }}
+    # TODO add back: vars.CONTAINER||
+    container: ${{ 'wpilib/roborio-cross-ubuntu' }}
     steps:
+    - name: Warn if not set
+      if: vars.RUNNER != 'ubuntu-latest'
+      run: echo "This step will be skipped on Monday and Wednesday"
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v6
     # Declares the repository safe and not under dubious ownership.

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -19,9 +19,9 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.RUNNER }}
     # This grabs the WPILib docker container
-    container: wpilib/roborio-cross-ubuntu:2025-22.04
+    container: ${{ vars.CONTAINER }}
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v6

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -18,9 +18,10 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
+    # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     runs-on: ${{ vars.RUNNER }}
     # This grabs the WPILib docker container
+    # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     container: ${{ vars.CONTAINER }}
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -8,7 +8,7 @@
 name: Java CI with Gradle, with basic WPILib integration
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch.
-on: 
+on:
   push:
     branches: [ "main" ]
   pull_request:
@@ -19,7 +19,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ${{ vars.RUNNER }}
+    runs-on: ubuntu-22.04-arm
     # This grabs the WPILib docker container
     container: ${{ vars.CONTAINER }}
     steps:

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -19,7 +19,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04-arm
+    runs-on: ${{ vars.CONTAINER }}
     # This grabs the WPILib docker container
     container: ${{ vars.CONTAINER }}
     steps:

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -18,16 +18,20 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings 
+    # The type of runner that the job will run on.  
     runs-on: ${{vars.RUNNER||'ubuntu-latest' }}
     # This grabs the WPILib docker container
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     container: ${{vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04' }}
     steps:
-    #THIS ALWAYS RUNS, TODO FIX
+  # THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings alongside the container
     - name: Warn if runner is not set
       if: vars.RUNNER == 'ubuntu-latest'
       run: echo "::warning ::The RUNNER variable is not set" 
+      #AS SAID ABOVE, THIS MUST BE SET YEARLY
+    - name: Warn if container is not set
+      if: vars.CONTAINER == 'wpilib/roborio-cross-ubuntu:2025-22.04'
+      run: echo "::warning ::The CONTAINER variable is not set" 
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v6
     # Declares the repository safe and not under dubious ownership.

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -24,7 +24,7 @@ jobs:
     # This grabs the WPILib docker container
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     # TODO add back: vars.CONTAINER||
-    container: ${{ 'wpilib/roborio-cross-ubuntu' }}
+    container: ${{'wpilib/roborio-cross-ubuntu:2025-22.04' }}
     steps:
     - name: Warn if not set
       if: vars.RUNNER != 'ubuntu-latest'

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -19,7 +19,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ${{ vars.CONTAINER }}
+    runs-on: ${{ vars.RUNNER }}
     # This grabs the WPILib docker container
     container: ${{ vars.CONTAINER }}
     steps:

--- a/.github/workflows/Build Validation.yml
+++ b/.github/workflows/Build Validation.yml
@@ -19,10 +19,10 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    runs-on: ${{ vars.RUNNER }}
+    runs-on: ${{ vars.RUNNER||'ubuntu-22.04' }}
     # This grabs the WPILib docker container
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    container: ${{ vars.CONTAINER }}
+    container: ${{ vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04' }}
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v6

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04-arm
+    runs-on: ${{ vars.CONTAINER }}
     # This grabs the WPILib docker container
     container: ${{ vars.CONTAINER }}
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -36,7 +36,6 @@ jobs:
           #Sets up branch system properly per https://github.com/marketplace/actions/add-commit#working-with-prs
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          run: echo Trigged by ${{ github.event_name }}  
           
       - name: Check with spotless
         id: spot-check

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    runs-on: ubuntu-slim
+    runs-on: ${{vars.RUNNER||'ubuntu-22.04'}}
     # This grabs the WPIlib docker container. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     container: ${{ vars.CONTAINER}}
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -19,7 +19,7 @@ jobs:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     runs-on: ${{vars.RUNNER||'ubuntu-22.04'}}
     # This grabs the WPIlib docker container. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    container: ${{ vars.CONTAINER}}
+    container: ${{vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04'}}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -19,26 +19,25 @@ jobs:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     runs-on: ${{vars.RUNNER||'ubuntu-latest'}}
     # This grabs the WPIlib docker container. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    container: ${{vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04'}}
+    container: ${{vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-24.04'}}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout repo (Pull Request)
-        #Checks if the event was trigged by a pull request, this step will be skipped if not.
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Checkout repository
+        #Uses the built-in checkout action
+        if: ${{github.event_name != 'pull_request'}} 
+        uses: actions/checkout@v5
+        
+      - name: Checkout repository (Pull Request Specific)
+        #Checks if the event was triggered by a pull request.
+        if: ${{github.event_name == 'pull_request'}} 
         uses: actions/checkout@v5
         with:
           #Sets up branch system properly per https://github.com/marketplace/actions/add-commit#working-with-prs
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-      - name: Checkout repo (Manually Run)
-        #Only runs if triggered manually
-        if: ${{github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v5
-      - name: Checkout repo (Push to main)
-        #Only runs if triggered manually
-        if: ${{github.event_name == 'push' }}
-        uses: actions/checkout@v5
+          run: echo Trigged by ${{ github.event_name }}  
+          
       - name: Check with spotless
         id: spot-check
         run: ./gradlew spotlessCheck
@@ -47,7 +46,7 @@ jobs:
         run: ./gradlew spotlessApply
       - name: Commit changes
         if: ${{ failure() && steps.spot-check.conclusion == 'failure' }}
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
           message: 'Formatted code using spotless.'

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -16,9 +16,9 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   spotless-check:
-    # The type of runner that the job will run on
+    # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     runs-on: ${{ vars.RUNNER }}
-    # This grabs the WPILib docker container
+    # This grabs the WPIlib docker container. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     container: ${{ vars.CONTAINER }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,7 +17,9 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.RUNNER }}
+    # This grabs the WPILib docker container
+    container: ${{ vars.CONTAINER }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -37,12 +39,6 @@ jobs:
         #Only runs if triggered manually
         if: ${{github.event_name == 'push' }}
         uses: actions/checkout@v5
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'zulu'
-          java-version: 17
-          cache: 'gradle'
       - name: Check with spotless
         id: spot-check
         run: ./gradlew spotlessCheck

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,9 +17,9 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    runs-on: ${{ vars.RUNNER }}
+    runs-on: ${{ vars.RUNNER }} || ubuntu-22.04
     # This grabs the WPIlib docker container. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    container: ${{ vars.CONTAINER }}
+    container: ${{ vars.CONTAINER }} || wpilib/roborio-cross-ubuntu:2025-22.04
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on
-    runs-on: ${{ vars.RUNNER }}
+    runs-on: ubuntu-22.04-arm
     # This grabs the WPILib docker container
     container: ${{ vars.CONTAINER }}
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on
-    runs-on: ${{ vars.CONTAINER }}
+    runs-on: ${{ vars.RUNNER }}
     # This grabs the WPILib docker container
     container: ${{ vars.CONTAINER }}
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,9 +17,9 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    runs-on: ${{ vars.RUNNER }} || ubuntu-22.04
+    runs-on: ubuntu-slim
     # This grabs the WPIlib docker container. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    container: ${{ vars.CONTAINER }} || wpilib/roborio-cross-ubuntu:2025-22.04
+    container: ${{ vars.CONTAINER}}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   spotless-check:
     # The type of runner that the job will run on. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
-    runs-on: ${{vars.RUNNER||'ubuntu-22.04'}}
+    runs-on: ${{vars.RUNNER||'ubuntu-latest'}}
     # This grabs the WPIlib docker container. THIS MUST BE SET YEARLY PER https://hub.docker.com/r/wpilib/roborio-cross-ubuntu in repo settings
     container: ${{vars.CONTAINER||'wpilib/roborio-cross-ubuntu:2025-22.04'}}
     # Steps represent a sequence of tasks that will be executed as part of the job


### PR DESCRIPTION
This changes both our CI to use the container as opposed to just build validation, which increases consistency. Additionally, by requiring said publicly visible variables we ensure that it must be updated year to year and doing so is extremely easy.